### PR TITLE
Update environment.yaml to avoid pip errors

### DIFF
--- a/environments/ncar-env/environment.yaml
+++ b/environments/ncar-env/environment.yaml
@@ -37,7 +37,7 @@ dependencies:
 - holoviews
 - hvplot
 - intake
-# - intake-esm # pending merge of git+https://github.com/andersy005/intake-esm.git@refactor#egg=intake-esm
+- intake-esm
 - intake-stac
 - intake-xarray
 - ipyleaflet
@@ -115,6 +115,5 @@ dependencies:
 - zarr
 - pip:
   - git+https://github.com/ian-r-rose/dask-labextension.git@de-asyncify#egg=dask_labextension
-  - git+https://github.com/andersy005/intake-esm.git@refactor#egg=intake-esm
   - graphviz
   - ncar-jobqueue


### PR DESCRIPTION
The branch for intake-esm specified in the pip block of the NCAR environment no
longer exists, and conda-forge now has a version of intake-esm incorporating
the changes needed from the now-defunct branch.